### PR TITLE
支持转移到现有的服务器中

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+.idea/
+
+*.iml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 ### 配置文件
 
+<details>
+<summary>config.yml</summary>
+
 ```yml
 # 服务器列表
 server-info:
@@ -42,39 +45,17 @@ ServerCloseTransfer:
   - lobby2
 ```
 
+</details>
+
+
 ### **注意事项**
 
-#### 一、
-
-- **`server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口一致，才能够正常的使用**
-- **特别是在与 `WaterdogPE` 搭配使用时子服的 `server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口必须一致才能够正常的使用，通常子服的ip是填写成 `127.0.0.1`**
+#### 一、**启用多服务器转移注意事项**
+- **`ServerCloseTransfer.ServerList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
 - **与 `WaterdogPE` 搭配使用示例在下方给出**
 
-**lobby1**
-```properties
-server-port=19201
-server-ip=127.0.0.1
-```
-**lobby2**
-```properties
-server-port=19202
-server-ip=127.0.0.1
-```
-**config.yml**
-```yml
-server-info:
-  - name: "lobby1"
-    group: "lobby"
-    ip: "127.0.0.1"
-    port: 19201
-  - name: "lobby2"
-    group: "lobby"
-    ip: "127.0.0.1"
-    port: 19202
-```
-
-#### 二、
-- **`ServerCloseTransfer.ServerList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
+<details>
+<summary>ServerInfo config.yml</summary>
 
 ```yml
 
@@ -107,3 +88,50 @@ ServerCloseTransfer:
   - lobby1
   - lobby2
 ```
+
+</details>
+
+#### 二、**与 WaterdogPE 搭配使用的注意事项**
+
+- **`server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口一致，才能够正常的使用**
+- **特别是在与 `WaterdogPE` 搭配使用时子服的 `server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口必须一致才能够正常的使用，通常子服的ip是填写成 `127.0.0.1`**
+- **示例在下方给出**
+
+<details>
+<summary>lobby1 server.properties</summary>
+
+```properties
+server-port=19201
+server-ip=127.0.0.1
+```
+
+</details>
+
+<details>
+<summary>lobby2 server.properties</summary>
+
+```properties
+server-port=19202
+server-ip=127.0.0.1
+```
+
+</details>
+
+<details>
+<summary>WaterdogPE config.yml</summary>
+
+```yml
+server-info:
+  - name: "lobby1"
+    group: "lobby"
+    ip: "127.0.0.1"
+    port: 19201
+  - name: "lobby2"
+    group: "lobby"
+    ip: "127.0.0.1"
+    port: 19202
+```
+
+</details>
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
-# ServerInfo
-#### Nukkit服务器的跨服菜单
-##### 可显示在线人数
+# **ServerInfo**
+[下载地址](https://ci.lanink.cn/view/SmallasWater/job/ServerInfo/)
+- Nukkit服务器的跨服菜单
+- 显示服务器的在线人数
+
+## 使用介绍
+- **命令 /trs**
+
+### 配置文件
+
+```yml
+# 服务器列表
+server-info:
+  - name: "测试服务器 #1"
+    group: "测试服务器组"
+    ip: "127.0.0.1"
+    port: 19132
+
+# 服务器信息更新方式 可选: Simple, Details
+UpdateInfoProvide: "Simple"
+
+# 在MOTD显示所有服务器的玩家数量总数
+sync-player: false
+
+#服务器关闭时传送到其他服务器
+ServerCloseTransfer:
+  enable: false
+  showTitle:
+    title: "服务器即将关闭!"
+    subTitle: "您将会被转移到其他服务器!"
+  ip: "127.0.0.1"
+  port: 19132
+  # 为 true 时将在 serverList 中寻找可用的服务器进行转移
+  # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+  TransferMode: false
+  # 可转移的服务器列表，名称为 server-info 中定义的 name
+  # 例如：name 定义了 lobby1 就填写 lobby1
+  serverList:
+  - lobby1
+  - lobby2
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 - 显示服务器的在线人数
 
 ## 使用介绍
-- **命令 /trs**
+- **命令: /trs**
+- **在启用多服务器转移时建议看完注意事项**
 
 ### 配置文件
 
@@ -47,17 +48,20 @@ ServerCloseTransfer:
 
 </details>
 
-
 ### **注意事项**
+- **给出是示例配置文件会省略部分无关的配置项，只会给出跟功能相关的配置项**
+- **在下方会将 `WaterdogPE` 简写为 `WDPE`，仅有部分内容保留 `WaterdogPE` 的写法**
 
 #### 一、**启用多服务器转移注意事项**
-- **`ServerCloseTransfer.ServerList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
-- **与 `WaterdogPE` 搭配使用示例在下方给出**
+1. **`ServerCloseTransfer.ServerList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
+
+- **与 `WDPE` 搭配使用示例在下方给出**
 
 <details>
 <summary>ServerInfo config.yml</summary>
 
 ```yml
+# 省略了部分无关的配置项
 
 server-info:
   - name: "lobby1"
@@ -71,17 +75,8 @@ server-info:
 
 #服务器关闭时传送到其他服务器
 ServerCloseTransfer:
-  enable: false
-  showTitle:
-    title: "服务器即将关闭!"
-    subTitle: "您将会被转移到其他服务器!"
-  ip: "127.0.0.1"
-  port: 19132
-  # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
-  # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+  enable: true
   TransferMode: true
-  # 如果使用 WaterdogPE 则启用该功能
-  use-WaterdogPE: false
  # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
   ServerList:
@@ -91,10 +86,11 @@ ServerCloseTransfer:
 
 </details>
 
-#### 二、**与 WaterdogPE 搭配使用的注意事项**
+#### 二、**启用多服务器转移并与 WDPE 搭配使用的注意事项**
 
-- **`server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口一致，才能够正常的使用**
-- **特别是在与 `WaterdogPE` 搭配使用时子服的 `server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口必须一致才能够正常的使用，通常子服的ip是填写成 `127.0.0.1`**
+1. **`server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口一致，才能够正常的使用**
+2. **特别是在与 `WDPE` 搭配使用时子服的 `server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口必须一致才能够正常的使用，通常子服的ip是填写成 `127.0.0.1`**
+
 - **示例在下方给出**
 
 <details>
@@ -118,9 +114,11 @@ server-ip=127.0.0.1
 </details>
 
 <details>
-<summary>WaterdogPE config.yml</summary>
+<summary>WDPE config.yml</summary>
 
 ```yml
+# 省略了部分无关的配置项
+
 server-info:
   - name: "lobby1"
     group: "lobby"
@@ -130,8 +128,55 @@ server-info:
     group: "lobby"
     ip: "127.0.0.1"
     port: 19202
+
+
+#服务器关闭时传送到其他服务器
+ServerCloseTransfer:
+  enable: true
+  # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
+  # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+  TransferMode: true
+  # 如果使用 WaterdogPE 则启用该功能
+  use-WaterdogPE: true
+  # 可转移的服务器列表，名称为 server-info 中定义的 name
+  # 例如：name 定义了 lobby1 就填写 lobby1
+  ServerList:
+    - lobby1
+    - lobby2
 ```
 
 </details>
 
+#### 三、启用多服务器转移但不搭配 WDPE 来使用****
+1. **服务端的 `server-ip=` 为 `0.0.0.0` 即可**
+2. **因为服务器的ip和port(端口)是判断可供转移的服务器是否为当前服务器的，所以是需要修改 `ServerCloseTransfer.ip` 的ip来实现以防玩家转移原服务器**
 
+```yml
+# 省略了部分无关的配置项
+
+server-info:
+  - name: "lobby1"
+    group: "lobby"
+    ip: "mc.example.com"
+    port: 19201
+  - name: "lobby2"
+    group: "lobby"
+    ip: "mc.example.com"
+    port: 19202
+
+
+#服务器关闭时传送到其他服务器
+ServerCloseTransfer:
+  enable: true
+  ip: "mc.example.com"
+  # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
+  # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+  TransferMode: true
+  # 如果使用 WaterdogPE 则启用该功能
+  use-WaterdogPE: false
+  # 可转移的服务器列表，名称为 server-info 中定义的 name
+  # 例如：name 定义了 lobby1 就填写 lobby1
+  ServerList:
+    - lobby1
+    - lobby2
+```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ server-info:
 #### 二、
 - **`ServerCloseTransfer.ServerList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
 
-
 ```yml
 
 server-info:

--- a/README.md
+++ b/README.md
@@ -39,3 +39,68 @@ ServerCloseTransfer:
   - lobby1
   - lobby2
 ```
+
+### **注意事项**
+
+#### 一、
+
+- **`server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口一致，才能够正常的使用**
+- **特别是在与 `WaterdogPE` 搭配使用时子服的 `server.properties` 要与本插件的配置文件中的 `server-info` 定义的ip端口必须一致才能够正常的使用，通常子服的ip是填写成 `127.0.0.1`**
+- **与 `WaterdogPE` 搭配使用示例在下方给出**
+
+**lobby1**
+```properties
+server-port=19201
+server-ip=127.0.0.1
+```
+**lobby2**
+```properties
+server-port=19202
+server-ip=127.0.0.1
+```
+**config.yml**
+```yml
+server-info:
+  - name: "lobby1"
+    group: "lobby"
+    ip: "127.0.0.1"
+    port: 19201
+  - name: "lobby2"
+    group: "lobby"
+    ip: "127.0.0.1"
+    port: 19202
+```
+
+#### 二、
+- **`ServerCloseTransfer.serverList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
+
+
+```yml
+
+server-info:
+  - name: "lobby1"
+    group: "lobby"
+    ip: "127.0.0.1"
+    port: 19201
+  - name: "lobby2"
+    group: "lobby"
+    ip: "127.0.0.1"
+    port: 19202
+
+#服务器关闭时传送到其他服务器
+ServerCloseTransfer:
+  enable: false
+  showTitle:
+    title: "服务器即将关闭!"
+    subTitle: "您将会被转移到其他服务器!"
+  ip: "127.0.0.1"
+  port: 19132
+  # 为 true 时将在 serverList 中寻找可用的服务器进行转移
+  # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+  TransferMode: true
+  # 可转移的服务器列表，名称为 server-info 中定义的 name
+  # 例如：name 定义了 lobby1 就填写 lobby1
+  serverList:
+  - lobby1
+  - lobby2
+```

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ ServerCloseTransfer:
     subTitle: "您将会被转移到其他服务器!"
   ip: "127.0.0.1"
   port: 19132
-  # 为 true 时将在 serverList 中寻找可用的服务器进行转移
+  # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
   # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: false
   # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
-  serverList:
+  ServerList:
   - lobby1
   - lobby2
 ```
@@ -72,7 +72,7 @@ server-info:
 ```
 
 #### 二、
-- **`ServerCloseTransfer.serverList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
+- **`ServerCloseTransfer.ServerList` 配置的服务器名是在 `server-info` 中定义的，定义的名字为 `lobby1` 就填写 `lobby1`**
 
 
 ```yml
@@ -95,12 +95,12 @@ ServerCloseTransfer:
     subTitle: "您将会被转移到其他服务器!"
   ip: "127.0.0.1"
   port: 19132
-  # 为 true 时将在 serverList 中寻找可用的服务器进行转移
+  # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
   # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: true
   # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
-  serverList:
+  ServerList:
   - lobby1
   - lobby2
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ServerCloseTransfer:
   # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
   # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: false
+  # 如果使用 WaterdogPE 则启用该功能
+  use-WaterdogPE: false
   # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
   ServerList:
@@ -97,7 +99,9 @@ ServerCloseTransfer:
   # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
   # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: true
-  # 可转移的服务器列表，名称为 server-info 中定义的 name
+  # 如果使用 WaterdogPE 则启用该功能
+  use-WaterdogPE: false
+ # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
   ServerList:
   - lobby1

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -241,6 +241,15 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
             return;
         }
 
+        LinkedList<ServerInfo> servers = new LinkedList<>();
+        LinkedList<String> strings = new LinkedList<>(this.getConfig().getStringList("ServerCloseTransfer.serverList"));
+        String sip = this.getServer().getIp() + ":" + this.getServer().getPort();
+        for (ServerInfo targetServer : serverInfos) {
+            if (strings.contains(targetServer.getName()) && targetServer.onLine() && !targetServer.isFull() && !sip.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+                servers.add(targetServer);
+            }
+        }
+
         for (Player player : this.getServer().getOnlinePlayers().values()) {
             player.sendTitle(
                     this.getConfig().getString("ServerCloseTransfer.showTitle.title"),
@@ -255,13 +264,17 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+        String ip = this.getConfig().getString("ServerCloseTransfer.ip");
+        int port = this.getConfig().getInt("ServerCloseTransfer.port");
 
         for (Player player : this.getServer().getOnlinePlayers().values()) {
+            ServerInfo targetServer = servers.get(new Random().nextInt(servers.size()));
+            if (this.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
+                ip = targetServer.getIp();
+                port = targetServer.getPort();
+            }
             player.transfer(
-                    new InetSocketAddress(
-                            this.getConfig().getString("ServerCloseTransfer.ip"),
-                            this.getConfig().getInt("ServerCloseTransfer.port")
-                    )
+                    new InetSocketAddress(ip, port)
             );
         }
         try {

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -20,7 +20,6 @@ import com.smallaswater.serverinfo.utils.TipsVariable;
 import com.smallaswater.serverinfo.utils.VariableUpdateTask;
 import com.smallaswater.serverinfo.windows.CreateAdminWindow;
 import com.smallaswater.serverinfo.windows.CreateWindow;
-import com.smallaswater.serverinfo.windows.ServerStopListener;
 import lombok.Getter;
 import tip.utils.Api;
 

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -243,10 +243,14 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
 
         LinkedList<ServerInfo> servers = new LinkedList<>();
         LinkedList<String> strings = new LinkedList<>(this.getConfig().getStringList("ServerCloseTransfer.serverList"));
-        String sip = this.getServer().getIp() + ":" + this.getServer().getPort();
+        String currentServer = this.getServer().getIp() + ":" + this.getServer().getPort();
+        String currentServerName = "";
         for (ServerInfo targetServer : serverInfos) {
-            if (strings.contains(targetServer.getName()) && targetServer.onLine() && !targetServer.isFull() && !sip.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+            if (strings.contains(targetServer.getName()) && targetServer.onLine() && !targetServer.isFull() && !currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
                 servers.add(targetServer);
+            }
+            if (currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+                currentServerName = targetServer.getName();
             }
         }
 
@@ -272,6 +276,7 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
             if (this.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
                 ip = targetServer.getIp();
                 port = targetServer.getPort();
+                player.sendMessage(language.getString("player-transfer-restart").replace("{currentServer}", currentServerName).replace("{targetServer}", targetServer.getName()));
             }
             player.transfer(
                     new InetSocketAddress(ip, port)

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -258,9 +258,7 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
             player.sendTitle(
                     this.getConfig().getString("ServerCloseTransfer.showTitle.title"),
                     this.getConfig().getString("ServerCloseTransfer.showTitle.subTitle"),
-                    10,
-                    100,
-                    20
+                    10, 100, 20
             );
         }
         try {
@@ -276,7 +274,7 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
             if (this.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
                 ip = targetServer.getIp();
                 port = targetServer.getPort();
-                player.sendMessage(language.getString("player-transfer-restart").replace("{currentServer}", currentServerName).replace("{targetServer}", targetServer.getName()));
+                player.sendMessage(language.getString("player-transfer-serverShutdown").replace("{currentServer}", currentServerName).replace("{targetServer}", targetServer.getName()));
             }
             player.transfer(
                     new InetSocketAddress(ip, port)

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ThreadPoolExecutor;
  * Create on 2021/7/13 15:23
  * Package com.smallaswater.serverinfo
  */
-public class ServerInfoMainClass extends PluginBase implements Listener{
+public class ServerInfoMainClass extends PluginBase implements Listener {
 
 
     public static final ThreadPoolExecutor THREAD_POOL = (ThreadPoolExecutor) Executors.newCachedThreadPool();
@@ -100,6 +100,7 @@ public class ServerInfoMainClass extends PluginBase implements Listener{
             THREAD_POOL.execute(new UpdateServerInfoRunnable());
         });
 
+        this.getServer().getPluginManager().registerEvents(this, this);
         this.getServer().getPluginManager().registerEvents(new ServerStopListener(), this);
 
         boolean needVariableUpdate = false;

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -65,6 +65,7 @@ public class ServerInfoMainClass extends PluginBase implements Listener{
 
     @Override
     public void onEnable() {
+        updateConfig();
         try {
             Class.forName("cn.lanink.gamecore.GameCore");
             this.hasGameCore = true;
@@ -231,5 +232,19 @@ public class ServerInfoMainClass extends PluginBase implements Listener{
                 event.getPlayer().sendMessage(TextFormat.colorize('&', language.getString("player-transfer-off")));
             }
         }
+    }
+
+    public void updateConfig() {
+        Config config = getConfig();
+        if (!config.exists("ServerCloseTransfer.TransferMode")) {
+            config.set("ServerCloseTransfer.TransferMode", false);
+        }
+        if (!config.exists("ServerCloseTransfer.use-WaterdogPE")) {
+            config.set("ServerCloseTransfer.use-WaterdogPE", false);
+        }
+        if (!config.exists("ServerCloseTransfer.ServerList")) {
+            config.set("ServerCloseTransfer.ServerList", Arrays.asList(""));
+        }
+        config.save();
     }
 }

--- a/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerInfoMainClass.java
@@ -242,7 +242,7 @@ public class ServerInfoMainClass extends PluginBase implements Listener {
         }
 
         LinkedList<ServerInfo> servers = new LinkedList<>();
-        LinkedList<String> strings = new LinkedList<>(this.getConfig().getStringList("ServerCloseTransfer.serverList"));
+        LinkedList<String> strings = new LinkedList<>(this.getConfig().getStringList("ServerCloseTransfer.ServerList"));
         String currentServer = this.getServer().getIp() + ":" + this.getServer().getPort();
         String currentServerName = "";
         for (ServerInfo targetServer : serverInfos) {

--- a/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
@@ -16,30 +16,26 @@ public class ServerStopListener implements Listener {
     public void onServerStop(ServerStopEvent event) {
         ServerInfoMainClass main = ServerInfoMainClass.getInstance();
         
-        if (!main.getConfig().getBoolean("ServerCloseTransfer.enable") ||
-                main.getServer().getOnlinePlayers().isEmpty()) {
+        if (!main.getConfig().getBoolean("ServerCloseTransfer.enable") || main.getServer().getOnlinePlayers().isEmpty()) {
             return;
         }
 
         LinkedList<ServerInfo> servers = new LinkedList<>();
-        LinkedList<String> strings = new LinkedList<>(main.getConfig().getStringList("ServerCloseTransfer.ServerList"));
-        String currentServer = "";
+        LinkedList<String> targetServers = new LinkedList<>(main.getConfig().getStringList("ServerCloseTransfer.ServerList"));
+        String currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
         String currentServerName = "";
-        boolean isCurrentServer;
         if (main.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
             if (main.getConfig().getBoolean("ServerCloseTransfer.use-WaterdogPE", false)) {
                 if (main.getServer().getIp().equals("0.0.0.0")) {
                     currentServer = "127.0.0.1:" + main.getServer().getPort();
-                }else {
-                    currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
                 }
-            }else {
-                currentServer =  main.getServer().getIp() + ":" + main.getServer().getPort();
+            }else if (main.getServer().getIp().equals("0.0.0.0")) {
+                currentServer = main.getConfig().getString("ServerCloseTransfer.ip") + ":" + main.getServer().getPort();
             }
 
             for (ServerInfo targetServer : main.getServerInfos()) {
-                isCurrentServer = currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort());
-                if (strings.contains(targetServer.getName()) && targetServer.onLine() && isCurrentServer) {
+                boolean isCurrentServer = currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort());
+                if (targetServers.contains(targetServer.getName()) && targetServer.onLine() && isCurrentServer) {
                     servers.add(targetServer);
                 }
                 if (isCurrentServer) {

--- a/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
@@ -1,10 +1,9 @@
-package com.smallaswater.serverinfo.windows;
+package com.smallaswater.serverinfo;
 
 import cn.nukkit.Player;
 import cn.nukkit.event.EventHandler;
 import cn.nukkit.event.Listener;
 import cn.nukkit.event.server.ServerStopEvent;
-import com.smallaswater.serverinfo.ServerInfoMainClass;
 import com.smallaswater.serverinfo.servers.ServerInfo;
 
 import java.net.InetSocketAddress;

--- a/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
@@ -24,24 +24,27 @@ public class ServerStopListener implements Listener {
         LinkedList<ServerInfo> servers = new LinkedList<>();
         LinkedList<String> strings = new LinkedList<>(main.getConfig().getStringList("ServerCloseTransfer.ServerList"));
         String currentServer = "";
-        boolean isCurrentServer = false;
-        if (main.getConfig().getBoolean("ServerCloseTransfer.use-WaterdogPE", false)) {
-            if (main.getServer().getIp().equals("0.0.0.0")) {
-                currentServer = "127.0.0.1:" + main.getServer().getPort();
-            }else {
-                currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
-            }
-        }else {
-            currentServer =  main.getServer().getIp() + ":" + main.getServer().getPort();
-        }
         String currentServerName = "";
-        for (ServerInfo targetServer : main.getServerInfos()) {
-            isCurrentServer = currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort());
-            if (strings.contains(targetServer.getName()) && targetServer.onLine() && isCurrentServer) {
-                servers.add(targetServer);
+        boolean isCurrentServer;
+        if (main.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
+            if (main.getConfig().getBoolean("ServerCloseTransfer.use-WaterdogPE", false)) {
+                if (main.getServer().getIp().equals("0.0.0.0")) {
+                    currentServer = "127.0.0.1:" + main.getServer().getPort();
+                }else {
+                    currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
+                }
+            }else {
+                currentServer =  main.getServer().getIp() + ":" + main.getServer().getPort();
             }
-            if (isCurrentServer) {
-                currentServerName = targetServer.getName();
+
+            for (ServerInfo targetServer : main.getServerInfos()) {
+                isCurrentServer = currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort());
+                if (strings.contains(targetServer.getName()) && targetServer.onLine() && isCurrentServer) {
+                    servers.add(targetServer);
+                }
+                if (isCurrentServer) {
+                    currentServerName = targetServer.getName();
+                }
             }
         }
 

--- a/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/ServerStopListener.java
@@ -64,7 +64,9 @@ public class ServerStopListener implements Listener {
             if (main.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
                 ip = targetServer.getIp();
                 port = targetServer.getPort();
-                player.sendMessage(main.getLanguage().getString("player-transfer-serverShutdown").replace("{currentServer}", currentServerName).replace("{targetServer}", targetServer.getName()));
+                if (main.getConfig().getBoolean("ServerCloseTransfer.use-WaterdogPE", false)) {
+                    player.sendMessage(main.getLanguage().getString("player-transfer-serverShutdown").replace("{currentServer}", currentServerName).replace("{targetServer}", targetServer.getName()));
+                }
             }
             player.transfer( new InetSocketAddress(ip, port) );
         }

--- a/src/main/java/com/smallaswater/serverinfo/windows/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/windows/ServerStopListener.java
@@ -24,7 +24,14 @@ public class ServerStopListener implements Listener {
 
         LinkedList<ServerInfo> servers = new LinkedList<>();
         LinkedList<String> strings = new LinkedList<>(main.getConfig().getStringList("ServerCloseTransfer.ServerList"));
-        String currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
+        String currentServer = "";
+        if (main.getConfig().getBoolean("ServerCloseTransfer.use-waterdogPe", false)) {
+            if (main.getServer().getIp().equals("0.0.0.0")) {
+                currentServer = "127.0.0.1:" + main.getServer().getPort();
+            }else {
+                currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
+            }
+        }
         String currentServerName = "";
         for (ServerInfo targetServer : main.getServerInfos()) {
             if (strings.contains(targetServer.getName()) && targetServer.onLine() && !targetServer.isFull() && !currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {

--- a/src/main/java/com/smallaswater/serverinfo/windows/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/windows/ServerStopListener.java
@@ -25,19 +25,23 @@ public class ServerStopListener implements Listener {
         LinkedList<ServerInfo> servers = new LinkedList<>();
         LinkedList<String> strings = new LinkedList<>(main.getConfig().getStringList("ServerCloseTransfer.ServerList"));
         String currentServer = "";
-        if (main.getConfig().getBoolean("ServerCloseTransfer.use-waterdogPe", false)) {
+        boolean isCurrentServer = false;
+        if (main.getConfig().getBoolean("ServerCloseTransfer.use-WaterdogPE", false)) {
             if (main.getServer().getIp().equals("0.0.0.0")) {
                 currentServer = "127.0.0.1:" + main.getServer().getPort();
             }else {
                 currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
             }
+        }else {
+            currentServer =  main.getServer().getIp() + ":" + main.getServer().getPort();
         }
         String currentServerName = "";
         for (ServerInfo targetServer : main.getServerInfos()) {
-            if (strings.contains(targetServer.getName()) && targetServer.onLine() && !targetServer.isFull() && !currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+            isCurrentServer = currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort());
+            if (strings.contains(targetServer.getName()) && targetServer.onLine() && isCurrentServer) {
                 servers.add(targetServer);
             }
-            if (currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+            if (isCurrentServer) {
                 currentServerName = targetServer.getName();
             }
         }

--- a/src/main/java/com/smallaswater/serverinfo/windows/ServerStopListener.java
+++ b/src/main/java/com/smallaswater/serverinfo/windows/ServerStopListener.java
@@ -1,0 +1,69 @@
+package com.smallaswater.serverinfo.windows;
+
+import cn.nukkit.Player;
+import cn.nukkit.event.EventHandler;
+import cn.nukkit.event.Listener;
+import cn.nukkit.event.server.ServerStopEvent;
+import com.smallaswater.serverinfo.ServerInfoMainClass;
+import com.smallaswater.serverinfo.servers.ServerInfo;
+
+import java.net.InetSocketAddress;
+import java.util.LinkedList;
+import java.util.Random;
+
+public class ServerStopListener implements Listener {
+    
+    @EventHandler
+    public void onServerStop(ServerStopEvent event) {
+        ServerInfoMainClass main = ServerInfoMainClass.getInstance();
+        
+        if (!main.getConfig().getBoolean("ServerCloseTransfer.enable") ||
+                main.getServer().getOnlinePlayers().isEmpty()) {
+            return;
+        }
+
+        LinkedList<ServerInfo> servers = new LinkedList<>();
+        LinkedList<String> strings = new LinkedList<>(main.getConfig().getStringList("ServerCloseTransfer.ServerList"));
+        String currentServer = main.getServer().getIp() + ":" + main.getServer().getPort();
+        String currentServerName = "";
+        for (ServerInfo targetServer : main.getServerInfos()) {
+            if (strings.contains(targetServer.getName()) && targetServer.onLine() && !targetServer.isFull() && !currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+                servers.add(targetServer);
+            }
+            if (currentServer.equals(targetServer.getIp() + ":" + targetServer.getPort())) {
+                currentServerName = targetServer.getName();
+            }
+        }
+
+        for (Player player : main.getServer().getOnlinePlayers().values()) {
+            player.sendTitle(
+                    main.getConfig().getString("ServerCloseTransfer.showTitle.title"),
+                    main.getConfig().getString("ServerCloseTransfer.showTitle.subTitle"),
+                    10, 100, 20
+            );
+        }
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        String ip = main.getConfig().getString("ServerCloseTransfer.ip");
+        int port = main.getConfig().getInt("ServerCloseTransfer.port");
+
+        for (Player player : main.getServer().getOnlinePlayers().values()) {
+            ServerInfo targetServer = servers.get(new Random().nextInt(servers.size()));
+            if (main.getConfig().getBoolean("ServerCloseTransfer.TransferMode",false)) {
+                ip = targetServer.getIp();
+                port = targetServer.getPort();
+                player.sendMessage(main.getLanguage().getString("player-transfer-serverShutdown").replace("{currentServer}", currentServerName).replace("{targetServer}", targetServer.getName()));
+            }
+            player.transfer( new InetSocketAddress(ip, port) );
+        }
+        try {
+            //让服务器发送完数据包再关闭
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/Language/chs/ConfigDescription.yml
+++ b/src/main/resources/Language/chs/ConfigDescription.yml
@@ -9,6 +9,7 @@ ServerCloseTransfer.port: "目标服务器端口"
 ServerCloseTransfer.TransferMode: |-
   为 true 时将在 ServerList 中寻找可用的服务器进行转移
   为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+ServerCloseTransfer.use-WaterdogPE: 如果使用 WaterdogPE 则启用该功能
 ServerCloseTransfer.ServerList: |-
   可转移的服务器列表，名称为 server-info 中定义的 name
   例如：name 定义了 lobby1 就填写 lobby1

--- a/src/main/resources/Language/chs/ConfigDescription.yml
+++ b/src/main/resources/Language/chs/ConfigDescription.yml
@@ -6,3 +6,9 @@ ServerCloseTransfer.enable: "是否启用"
 ServerCloseTransfer.showTitle: "提示内容"
 ServerCloseTransfer.ip: "目标服务器IP"
 ServerCloseTransfer.port: "目标服务器端口"
+ServerCloseTransfer.TransferMode: |-
+  为 true 时将在 ServerList 中寻找可用的服务器进行转移
+  为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
+ServerCloseTransfer.ServerList: |-
+  可转移的服务器列表，名称为 server-info 中定义的 name
+  例如：name 定义了 lobby1 就填写 lobby1

--- a/src/main/resources/Language/chs/language.yml
+++ b/src/main/resources/Language/chs/language.yml
@@ -23,6 +23,6 @@ button-text-online: "{server}\n &e{player} &7/&6 {maxplayer}  &a在线 版本: {
 button-text-full: "{server}\n &e{player} &7/&6 {maxplayer}  &a已满"
 button-text-offline: "{server}\n &e服务器离线"
 player-transfer-text: "&e玩家 &a{name} &e前往了 &r{server} &e服务器"
-player-transfer-restart: "正在将您从 {currentServer} 转移到 {targetServer}"
+player-transfer-serverShutdown: "§a正在将您从 {currentServer} 转移到 {targetServer}"
 player-transfer-full: "&e[&f跨服&e] 服务器已满"
 player-transfer-off: "&e[&f跨服&e] 服务器离线"

--- a/src/main/resources/Language/chs/language.yml
+++ b/src/main/resources/Language/chs/language.yml
@@ -23,5 +23,6 @@ button-text-online: "{server}\n &e{player} &7/&6 {maxplayer}  &a在线 版本: {
 button-text-full: "{server}\n &e{player} &7/&6 {maxplayer}  &a已满"
 button-text-offline: "{server}\n &e服务器离线"
 player-transfer-text: "&e玩家 &a{name} &e前往了 &r{server} &e服务器"
+player-transfer-restart: "正在将您从 {currentServer} 转移到 {targetServer}"
 player-transfer-full: "&e[&f跨服&e] 服务器已满"
 player-transfer-off: "&e[&f跨服&e] 服务器离线"

--- a/src/main/resources/Language/eng/ConfigDescription.yml
+++ b/src/main/resources/Language/eng/ConfigDescription.yml
@@ -6,3 +6,9 @@ ServerCloseTransfer.enable: "Enable this feature"
 ServerCloseTransfer.showTitle: "Notification message"
 ServerCloseTransfer.ip: "Target server IP"
 ServerCloseTransfer.port: "Target server port"
+ServerCloseTransfer.TransferMode: |-
+  When set to true, the system will search for an available server in ServerList to transfer to.
+  When set to false, it will transfer to the server defined by ServerCloseTransfer.ip & port.
+ServerCloseTransfer.ServerList: |-
+  List of transferable servers. The names should match the name defined in server-info.
+  Example: If the name is defined as lobby1, then enter lobby1.

--- a/src/main/resources/Language/eng/ConfigDescription.yml
+++ b/src/main/resources/Language/eng/ConfigDescription.yml
@@ -9,6 +9,7 @@ ServerCloseTransfer.port: "Target server port"
 ServerCloseTransfer.TransferMode: |-
   When set to true, the system will search for an available server in ServerList to transfer to.
   When set to false, it will transfer to the server defined by ServerCloseTransfer.ip & port.
+ServerCloseTransfer.use-WaterdogPE: Enable this feature if using WaterdogPE.
 ServerCloseTransfer.ServerList: |-
   List of transferable servers. The names should match the name defined in server-info.
   Example: If the name is defined as lobby1, then enter lobby1.

--- a/src/main/resources/Language/eng/language.yml
+++ b/src/main/resources/Language/eng/language.yml
@@ -23,5 +23,6 @@ button-text-online: "{server}\n &e{player} &7/&6 {maxplayer}  &aOnline Version: 
 button-text-full: "{server}\n &e{player} &7/&6 {maxplayer}  &aFull"
 button-text-offline: "{server}\n &eServer Offline"
 player-transfer-text: "&ePlayer &a{name} &ehas transferred to &r{server} &eserver"
+player-transfer-restart: "Transferring you from {currentServer} to {targetServer}"
 player-transfer-full: "&e[&fTransfer-Server&e] Server is full"
 player-transfer-off: "&e[&fTransfer-Server&e] Server offline"

--- a/src/main/resources/Language/eng/language.yml
+++ b/src/main/resources/Language/eng/language.yml
@@ -23,6 +23,6 @@ button-text-online: "{server}\n &e{player} &7/&6 {maxplayer}  &aOnline Version: 
 button-text-full: "{server}\n &e{player} &7/&6 {maxplayer}  &aFull"
 button-text-offline: "{server}\n &eServer Offline"
 player-transfer-text: "&ePlayer &a{name} &ehas transferred to &r{server} &eserver"
-player-transfer-restart: "Transferring you from {currentServer} to {targetServer}"
+player-transfer-serverShutdown: "§aTransferring you from {currentServer} to {targetServer}"
 player-transfer-full: "&e[&fTransfer-Server&e] Server is full"
 player-transfer-off: "&e[&fTransfer-Server&e] Server offline"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,3 +19,9 @@ ServerCloseTransfer:
     subTitle: "您将会被转移到其他服务器!"
   ip: "127.0.0.1"
   port: 19132
+  # 启用后将在 serverList 中寻找可用的服务器进行转移，若未启用则会转移到指定的服务器中
+  TransferMode: false
+  # 可转移的服务器列表，名称为 server-info 中定义的 name
+  serverList:
+  - lobby1
+  - lobby2

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,8 @@ ServerCloseTransfer:
   # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
   # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: false
+  # 如果使用 WaterdogPE 则启用该功能
+  use-WaterdogPE: false
   # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
   ServerList:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,11 +19,11 @@ ServerCloseTransfer:
     subTitle: "您将会被转移到其他服务器!"
   ip: "127.0.0.1"
   port: 19132
-  # 为 true 时将在 serverList 中寻找可用的服务器进行转移
+  # 为 true 时将在 ServerList 中寻找可用的服务器进行转移
   # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: false
   # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
-  serverList:
+  ServerList:
   - lobby1
   - lobby2

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,9 +19,11 @@ ServerCloseTransfer:
     subTitle: "您将会被转移到其他服务器!"
   ip: "127.0.0.1"
   port: 19132
-  # 启用后将在 serverList 中寻找可用的服务器进行转移，若未启用则会转移到指定的服务器中
+  # 为 true 时将在 serverList 中寻找可用的服务器进行转移
+  # 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
   TransferMode: false
   # 可转移的服务器列表，名称为 server-info 中定义的 name
+  # 例如：name 定义了 lobby1 就填写 lobby1
   serverList:
   - lobby1
   - lobby2

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,4 @@ ServerCloseTransfer:
   use-WaterdogPE: false
   # 可转移的服务器列表，名称为 server-info 中定义的 name
   # 例如：name 定义了 lobby1 就填写 lobby1
-  ServerList:
-  - lobby1
-  - lobby2
+  ServerList: []


### PR DESCRIPTION
增加可以转移到现有的服务器的功能，此功能在有多个服务器可供转移时会将玩家随机转移到可用的其中的一个服务器中
同时保留了原有的转移玩家的功能，如果只有一个可供转移的服务器可以使用原有的功能


在配置文件中新增两个设置
1. TransferMode
 - 为 true 时将在 ServerList 中寻找可用的服务器进行转移
 - 为 false 时则会转移到 ServerCloseTransfer.ip&prot 定义的服务器中
2.   ServerList:
 - 可转移的服务器列表，名称为 server-info 中定义的 name
 - 例如：name 定义了 lobby1 就填写 lobby1
